### PR TITLE
LPS-87976

### DIFF
--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
@@ -16,6 +16,8 @@ package com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.
 
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchClientResolver;
 import com.liferay.portal.search.elasticsearch6.internal.document.DefaultElasticsearchDocumentFactory;
 import com.liferay.portal.search.elasticsearch6.internal.document.ElasticsearchDocumentFactory;
@@ -90,9 +92,7 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 			IndexRequestBuilder indexRequestBuilder =
 				IndexAction.INSTANCE.newRequestBuilder(client);
 
-			Document document = indexDocumentRequest.getDocument();
-
-			indexRequestBuilder.setId(document.getUID());
+			setIdIndex(indexDocumentRequest, indexRequestBuilder);
 
 			indexRequestBuilder.setIndex(indexDocumentRequest.getIndexName());
 
@@ -105,6 +105,8 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 
 			ElasticsearchDocumentFactory elasticsearchDocumentFactory =
 				new DefaultElasticsearchDocumentFactory();
+
+			Document document = indexDocumentRequest.getDocument();
 
 			String elasticsearchDocument =
 				elasticsearchDocumentFactory.getElasticsearchDocument(document);
@@ -134,9 +136,7 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 			UpdateRequestBuilder updateRequestBuilder =
 				UpdateAction.INSTANCE.newRequestBuilder(client);
 
-			Document document = updateDocumentRequest.getDocument();
-
-			updateRequestBuilder.setId(document.getUID());
+			setIdUpdate(updateDocumentRequest, updateRequestBuilder);
 
 			updateRequestBuilder.setIndex(updateDocumentRequest.getIndexName());
 
@@ -149,6 +149,8 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 
 			ElasticsearchDocumentFactory elasticsearchDocumentFactory =
 				new DefaultElasticsearchDocumentFactory();
+
+			Document document = updateDocumentRequest.getDocument();
 
 			String elasticsearchDocument =
 				elasticsearchDocumentFactory.getElasticsearchDocument(document);
@@ -164,6 +166,34 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 		}
 		catch (IOException ioe) {
 			throw new SystemException(ioe);
+		}
+	}
+
+	protected void setIdIndex(
+		IndexDocumentRequest indexDocumentRequest,
+		IndexRequestBuilder indexRequestBuilder) {
+
+		Document document = indexDocumentRequest.getDocument();
+
+		Field field = document.getField(Field.UID);
+
+		if (field != null) {
+			String uid = field.getValue();
+
+			if (!Validator.isBlank(uid)) {
+				indexRequestBuilder.setId(uid);
+			}
+		}
+	}
+
+	protected void setIdUpdate(
+		UpdateDocumentRequest updateDocumentRequest,
+		UpdateRequestBuilder updateRequestBuilder) {
+
+		String uid = updateDocumentRequest.getUid();
+
+		if (!Validator.isBlank(uid)) {
+			updateRequestBuilder.setId(uid);
 		}
 	}
 

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslator.java
@@ -92,7 +92,9 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 			IndexRequestBuilder indexRequestBuilder =
 				IndexAction.INSTANCE.newRequestBuilder(client);
 
-			setIdIndex(indexDocumentRequest, indexRequestBuilder);
+			Document document = indexDocumentRequest.getDocument();
+
+			setIndexRequestBuilderId(indexRequestBuilder, document);
 
 			indexRequestBuilder.setIndex(indexDocumentRequest.getIndexName());
 
@@ -105,8 +107,6 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 
 			ElasticsearchDocumentFactory elasticsearchDocumentFactory =
 				new DefaultElasticsearchDocumentFactory();
-
-			Document document = indexDocumentRequest.getDocument();
 
 			String elasticsearchDocument =
 				elasticsearchDocumentFactory.getElasticsearchDocument(document);
@@ -136,7 +136,8 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 			UpdateRequestBuilder updateRequestBuilder =
 				UpdateAction.INSTANCE.newRequestBuilder(client);
 
-			setIdUpdate(updateDocumentRequest, updateRequestBuilder);
+			setUpdateRequestBuilderId(
+				updateRequestBuilder, updateDocumentRequest);
 
 			updateRequestBuilder.setIndex(updateDocumentRequest.getIndexName());
 
@@ -169,11 +170,8 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 		}
 	}
 
-	protected void setIdIndex(
-		IndexDocumentRequest indexDocumentRequest,
-		IndexRequestBuilder indexRequestBuilder) {
-
-		Document document = indexDocumentRequest.getDocument();
+	protected void setIndexRequestBuilderId(
+		IndexRequestBuilder indexRequestBuilder, Document document) {
 
 		Field field = document.getField(Field.UID);
 
@@ -186,15 +184,23 @@ public class ElasticsearchBulkableDocumentRequestTranslator
 		}
 	}
 
-	protected void setIdUpdate(
-		UpdateDocumentRequest updateDocumentRequest,
-		UpdateRequestBuilder updateRequestBuilder) {
+	protected void setUpdateRequestBuilderId(
+		UpdateRequestBuilder updateRequestBuilder,
+		UpdateDocumentRequest updateDocumentRequest) {
 
 		String uid = updateDocumentRequest.getUid();
 
-		if (!Validator.isBlank(uid)) {
-			updateRequestBuilder.setId(uid);
+		if (Validator.isBlank(uid)) {
+			Document document = updateDocumentRequest.getDocument();
+
+			Field field = document.getField(Field.UID);
+
+			if (field != null) {
+				uid = field.getValue();
+			}
 		}
+
+		updateRequestBuilder.setId(uid);
 	}
 
 	@Reference

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/IndexDocumentRequestExecutorImpl.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/IndexDocumentRequestExecutorImpl.java
@@ -48,7 +48,7 @@ public class IndexDocumentRequestExecutorImpl
 		RestStatus restStatus = indexResponse.status();
 
 		IndexDocumentResponse indexDocumentResponse = new IndexDocumentResponse(
-			restStatus.getStatus());
+			restStatus.getStatus(), indexResponse.getId());
 
 		return indexDocumentResponse;
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/search/engine/adapter/document/ElasticsearchBulkableDocumentRequestTranslatorTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.elasticsearch6.internal.search.engine.adapter.
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch6.internal.document.DefaultElasticsearchDocumentFactory;
 import com.liferay.portal.search.elasticsearch6.internal.document.ElasticsearchDocumentFactory;
@@ -92,7 +93,15 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		throws IOException {
 
 		doTestIndexDocumentRequestTranslation(
-			false, WriteRequest.RefreshPolicy.NONE);
+			"1", false, WriteRequest.RefreshPolicy.NONE);
+	}
+
+	@Test
+	public void testIndexDocumentRequestTranslationWithNoRefreshNoId()
+		throws IOException {
+
+		doTestIndexDocumentRequestTranslation(
+			null, false, WriteRequest.RefreshPolicy.NONE);
 	}
 
 	@Test
@@ -100,7 +109,15 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		throws IOException {
 
 		doTestIndexDocumentRequestTranslation(
-			true, WriteRequest.RefreshPolicy.IMMEDIATE);
+			"1", true, WriteRequest.RefreshPolicy.IMMEDIATE);
+	}
+
+	@Test
+	public void testIndexDocumentRequestTranslationWithRefreshNoId()
+		throws IOException {
+
+		doTestIndexDocumentRequestTranslation(
+			null, true, WriteRequest.RefreshPolicy.IMMEDIATE);
 	}
 
 	@Test
@@ -108,7 +125,15 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		throws IOException {
 
 		doTestUpdateDocumentRequestTranslation(
-			false, WriteRequest.RefreshPolicy.NONE);
+			"1", false, WriteRequest.RefreshPolicy.NONE);
+	}
+
+	@Test
+	public void testUpdateDocumentRequestTranslationWithNoRefreshNoId()
+		throws IOException {
+
+		doTestUpdateDocumentRequestTranslation(
+			null, false, WriteRequest.RefreshPolicy.NONE);
 	}
 
 	@Test
@@ -116,7 +141,15 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 		throws IOException {
 
 		doTestUpdateDocumentRequestTranslation(
-			true, WriteRequest.RefreshPolicy.IMMEDIATE);
+			"1", true, WriteRequest.RefreshPolicy.IMMEDIATE);
+	}
+
+	@Test
+	public void testUpdateDocumentRequestTranslationWithRefreshNoId()
+		throws IOException {
+
+		doTestUpdateDocumentRequestTranslation(
+			null, true, WriteRequest.RefreshPolicy.IMMEDIATE);
 	}
 
 	protected void doTestDeleteDocumentRequestTranslation(
@@ -155,15 +188,13 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 	}
 
 	protected void doTestIndexDocumentRequestTranslation(
-			boolean refreshPolicy,
+			String id, boolean refreshPolicy,
 			WriteRequest.RefreshPolicy expectedRefreshPolicy)
 		throws IOException {
 
-		String id = "1";
-
 		Document document = new DocumentImpl();
 
-		document.addKeyword(Field.UID, id);
+		_setUid(document, id);
 
 		IndexDocumentRequest indexDocumentRequest = new IndexDocumentRequest(
 			_INDEX_NAME, document);
@@ -205,15 +236,13 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 	}
 
 	protected void doTestUpdateDocumentRequestTranslation(
-			boolean refreshPolicy,
+			String id, boolean refreshPolicy,
 			WriteRequest.RefreshPolicy expectedRefreshPolicy)
 		throws IOException {
 
-		String id = "1";
-
 		Document document = new DocumentImpl();
 
-		document.addKeyword(Field.UID, id);
+		_setUid(document, id);
 
 		UpdateDocumentRequest updateDocumentRequest = new UpdateDocumentRequest(
 			_INDEX_NAME, id, document);
@@ -253,6 +282,12 @@ public class ElasticsearchBulkableDocumentRequestTranslatorTest {
 			updateDocumentRequest, bulkRequestBuilder);
 
 		Assert.assertEquals(1, bulkRequestBuilder.numberOfActions());
+	}
+
+	private void _setUid(Document document, String uid) {
+		if (!Validator.isBlank(uid)) {
+			document.addKeyword(Field.UID, uid);
+		}
 	}
 
 	private static final String _INDEX_NAME = "test_request_index";

--- a/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/IndexDocumentResponse.java
+++ b/modules/apps/portal-search/portal-search-engine-adapter-api/src/main/java/com/liferay/portal/search/engine/adapter/document/IndexDocumentResponse.java
@@ -22,14 +22,20 @@ import aQute.bnd.annotation.ProviderType;
 @ProviderType
 public class IndexDocumentResponse implements DocumentResponse {
 
-	public IndexDocumentResponse(int status) {
+	public IndexDocumentResponse(int status, String id) {
 		_status = status;
+		_id = id;
+	}
+
+	public String getId() {
+		return _id;
 	}
 
 	public int getStatus() {
 		return _status;
 	}
 
+	private final String _id;
 	private final int _status;
 
 }


### PR DESCRIPTION
Hey wade, i made a few changes, the most important being that i added an _id field to the IndexDocumentResponse.

Can you add some tests in `ElasticsearchSearchEngineAdapterDocumentRequestTest`. This test class is a little different than `ElasticsearchBulkableDocumentRequestTranslatorTest` because it tests the actual execution of the requests, instead of just testing the translators. These new tests will be similar to the ones you already wrote, we need to test different combinations of the uid being null in the document and/or the request. Also, we need to test the new `_id` field in the `IndexDocumentResponse`. This can be done by sending a document in an index request without an id, which will cause the search engine generate the id. The id will then be returned in the response, from which you extract and then use in an update request to update the original document.

Let me know if you have any questions, thanks!