### PR TITLE
LPS-99991 - Result Rankings: Pinned and Hidden results are not removed from search results after the underlying asset is deleted or moved to Recycle Bin

### DIFF
--- a/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/interpreter/SearchResultInterpreter.java
+++ b/modules/apps/portal-search/portal-search-web-api/src/main/java/com/liferay/portal/search/web/interpreter/SearchResultInterpreter.java
@@ -55,8 +55,7 @@ public interface SearchResultInterpreter {
 	public String getAssetIconCssClass(Document document)
 		throws PortalException;
 
-	public AssetRenderer<?> getAssetRenderer(Document document)
-		throws PortalException;
+	public AssetRenderer<?> getAssetRenderer(Document document);
 
 	public String getAssetSearchSummary(Document document, Locale locale)
 		throws PortalException;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/Interpreter/AssetRendererSearchResultInterpreter.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/Interpreter/AssetRendererSearchResultInterpreter.java
@@ -137,9 +137,7 @@ public class AssetRendererSearchResultInterpreter
 	}
 
 	@Override
-	public AssetRenderer<?> getAssetRenderer(Document document)
-		throws PortalException {
-
+	public AssetRenderer<?> getAssetRenderer(Document document) {
 		AssetRendererFactory<?> assetRendererFactory = getAssetRendererFactory(
 			document);
 
@@ -147,8 +145,13 @@ public class AssetRendererSearchResultInterpreter
 			return null;
 		}
 
-		return assetRendererFactory.getAssetRenderer(
-			GetterUtil.getLong(document.getLong(Field.ENTRY_CLASS_PK)));
+		try {
+			return assetRendererFactory.getAssetRenderer(
+				GetterUtil.getLong(document.getLong(Field.ENTRY_CLASS_PK)));
+		}
+		catch (Exception exception) {
+			return null;
+		}
 	}
 
 	@Override

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilder.java
@@ -104,7 +104,9 @@ public class SearchResultSummaryDisplayBuilder {
 			return build(className, classPK);
 		}
 		catch (Exception exception) {
-			_log.error(exception, exception);
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
 
 			return buildTemporarilyUnavailable();
 		}


### PR DESCRIPTION
http://issues.liferay.com/browse/LPS-99991

Hey Wade, this commit https://github.com/liferay/liferay-portal/commit/7cbddef6eae9fb4eb20bbfbeab94384017a876c0#diff-09f82b005b85e54cbf2d7e5de1f52d93R122-R130 made web contents throw an exception when they can't be found. This causes an error to be thrown on the Search Results portlet so I changed it to debug level instead since it's an expected error.

Let me know if you think there could be issues with this approach.

Thanks!